### PR TITLE
'cat count' documents for specific index

### DIFF
--- a/cmd/nox/cat.go
+++ b/cmd/nox/cat.go
@@ -43,11 +43,17 @@ var catAllocation = &cobra.Command{
 }
 
 var catCount = &cobra.Command{
-	Use:   "count",
+	Use:   "count [index]",
 	Short: "get document counts",
 	Long:  `Count provides quick access to the document count of the entire cluster, or individual indices`,
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		response := elastic.Cat(cmd.Name())
+		var response string
+		if len(args) > 0 {
+			response = elastic.CatCountIndex(args[0])
+		} else {
+			response = elastic.Cat(cmd.Name())
+		}
 		printResponse(response)
 	},
 }

--- a/internal/elastic/cat.go
+++ b/internal/elastic/cat.go
@@ -8,6 +8,11 @@ func Cat(action string) string {
 	return r
 }
 
+// CatCountIndex count documents for a specific index
+func CatCountIndex(index string) string {
+	return Cat("count/" + index)
+}
+
 // CatNodeType Cat nodes of a certain type
 func CatNodeType(nodetype string) []string {
 	resp := Cat("nodes")


### PR DESCRIPTION
Adds ability to count documents for a specific index.

```
Count provides quick access to the document count of the entire cluster, or individual indices

Usage:
  nox cat count [index] [flags]
  ...
```