### PR TITLE
Disable pretty printing when output is piped

### DIFF
--- a/cmd/nox/helpers.go
+++ b/cmd/nox/helpers.go
@@ -67,6 +67,11 @@ func isError(m string) bool {
 }
 
 func printResponse(m string) {
+	fo, _ := os.Stdout.Stat()
+	if (fo.Mode() & os.ModeCharDevice) == 0 {
+		viper.Set("pretty", false)
+	}
+
 	if viper.GetBool("silent") && !isError(m) {
 		return
 	} else if viper.GetBool("pretty") {


### PR DESCRIPTION
Currently when redirecting STDOUT to a pipe the JSON blob is pretty printed making it difficult to parse:
```
$ nox cluster health | jq .status
parse error: Invalid numeric literal at line 2, column 4
```

The same problem exists when outputting to a file, making it difficult to parse:
```
$ nox cluster health >health.json
$ strings health.json | head
[38;5;202m"cluster_name"
[0m :
[38;5;32m"cluster1"
[0m,
[38;5;202m"status"
[0m :
[38;5;32m"green"
```

While this can be disabled with `--pretty=false` this can be a little cumbersome:
```
$ nox --pretty=false cluster health | jq .status
"green"
```

This change automatically disables pretty printing when the output is not the terminal:
```
$ nox cluster health | jq .status
"green"
```

I still need to test the portability of this change. I wasn't entirely sure if this was the best place to put this logic, so I would appreciate advice there too.