### PR TITLE
Allow input from stdin instead of editor

### DIFF
--- a/cmd/nox/helpers.go
+++ b/cmd/nox/helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -43,13 +44,31 @@ func readFromFile() string {
 		return ""
 	}
 
-	body, err := goin.ReadFromFile(tempBufferFileName)
+	var body string
+	var err error
+
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		body, err = readFromStdin()
+	} else {
+		body, err = goin.ReadFromFile(tempBufferFileName)
+	}
+
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	return body
 
+}
+
+func readFromStdin() (string, error) {
+	bytes, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
 }
 
 func isError(m string) bool {


### PR DESCRIPTION
When using `nox` in a script it's necessary to be able to take input via stdin when required instead of from the editor.

As with #19 we can detect if there is data on stdin and simply read that for our input instead of launching the editor.