### PR TITLE
Add .tools-version, upgrade goreleaser

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang 1.15.6
-goreleaser 0.122.0
+goreleaser 0.149.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golang 1.15.6
+goreleaser 0.122.0

--- a/cmd/nox/.goreleaser.yml
+++ b/cmd/nox/.goreleaser.yml
@@ -10,17 +10,18 @@ archives:
 before:
   hooks:
     - "go mod download"
-brew:
-  commit_author:
-    email: maxine.krebs@procore.com
-    name: "Maxine Krebs"
-  description: "A grand unified Elasticsearch infrastructure management cli"
-  folder: Formula
-  github:
-    name: homebrew-formulae
-    owner: procore
-  name: nox
-  test: "system \"#{bin}/nox --help\"\n"
+brews:
+  -
+    commit_author:
+      email: maxine.krebs@procore.com
+      name: "Maxine Krebs"
+    description: "A grand unified Elasticsearch infrastructure management cli"
+    folder: Formula
+    github:
+      name: homebrew-formulae
+      owner: procore
+    name: nox
+    test: "system \"#{bin}/nox --help\"\n"
 builds:
   - main: ./
     env:

--- a/cmd/nox/.goreleaser.yml
+++ b/cmd/nox/.goreleaser.yml
@@ -17,7 +17,7 @@ brews:
       name: "Maxine Krebs"
     description: "A grand unified Elasticsearch infrastructure management cli"
     folder: Formula
-    github:
+    tap:
       name: homebrew-formulae
       owner: procore
     name: nox


### PR DESCRIPTION
Some housekeeping.  Title basically says it all.

Ran `make release-dry-run` in `cmd/elasticsearch_index_version_auditor` and no errors.

Some slight changes were necessary to account for some changes between `goreleaser` versions. Viewing the diff w/ whitespace ignored can highlight them a little better.